### PR TITLE
Improve mobile spacing

### DIFF
--- a/style.css
+++ b/style.css
@@ -143,6 +143,7 @@ main section {
 
 .overlay.details {
   margin-left: 2rem;
+  margin-right: 2rem;
   margin-top: 1rem;
   background: rgba(0,0,0,0.7);
   border-radius: 12px;
@@ -205,11 +206,18 @@ h1, h2, p {
     max-width: 90%;
     font-size: 0.9rem;
     text-align: left;
+    margin: 0 1rem;
+  }
+
+  .overlay.details {
+    margin-left: 1rem;
+    margin-right: 1rem;
   }
 
   .scrolly .step .overlay {
     left: 5%;
     width: 90%;
+    margin: 0;
   }
 
   .shape {


### PR DESCRIPTION
## Summary
- keep overlays away from screen edges on small viewports

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6857e64011948321b27cb714cd7592e7