### PR TITLE
Adjust scrolly section layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -64,7 +64,7 @@ main section {
 }
 
 .scrolly .step {
-  height: 120vh;
+  height: 90vh;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -170,7 +170,7 @@ h1, h2, p {
 .icon {
   margin-left: 0.4rem;
   color: #E7E7E7;
-  font-size: inherit;
+  font-size: 0.8em;
 }
 
 .skill-logo {
@@ -226,6 +226,6 @@ h1, h2, p {
   }
 
   .scrolly .step {
-    height: 120vh;
+    height: 90vh;
   }
 }


### PR DESCRIPTION
## Summary
- reduce `scrolly` step height so Experience and Leadership sections don't feel oversized
- shrink the icon size for section headings

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6857e9576e188321b35ee15851acb021