### PR TITLE
Restore scrolly steps for Experience/Leadership

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
       <p>With a background in computer science, I enjoy solving complex problems. Duis dapibus, nibh non pretium feugiat, dolor augue congue sapien, a gravida purus metus nec libero. Donec pharetra purus eget massa pulvinar, vel rhoncus lacus placerat.</p>
     </div>
   </section>
-  <section class="scrolly" style="background-image:url('https://images.unsplash.com/photo-1569668444050-b7bc2bfec0c7?w=4096')">
+  <section class="scrolly dark-bg" style="background-image:url('https://plus.unsplash.com/premium_photo-1699626665792-77b2eef3a0af?crop=entropy&amp;cs=tinysrgb&amp;fit=max&amp;fm=jpg&amp;ixid=M3wxMjA3fDB8MXxzZWFyY2h8MXx8ZWRpbmJ1cmdofGVufDB8fHx8MTc1MDU5NTU2OHww&amp;ixlib=rb-4.1.0&amp;q=80&amp;w=1080')">
     <div class="step">
       <div class="overlay main">
         <h2><span class="highlight">Experience</span><i class="fa-solid fa-briefcase icon"></i></h2>
@@ -49,7 +49,7 @@
         <p>From internships to personal projects, I constantly adapt and learn. Quisque id consequat sapien. Suspendisse malesuada dolor sed odio consequat, a posuere massa molestie. Aenean vel justo eget neque finibus luctus vel sed ipsum.</p>
       </div>
     </div>
-    <div class="step">
+    <div class="step" style="background-image:url('https://images.unsplash.com/photo-1506377585622-bedcbb027afc?crop=entropy&amp;cs=tinysrgb&amp;fit=max&amp;fm=jpg&amp;ixid=M3wxMjA3fDB8MXxzZWFyY2h8Mnx8ZWRpbmJ1cmdofGVufDB8fHx8MTc1MDUzODQ5M3ww&amp;ixlib=rb-4.1.0&amp;q=80&amp;w=1080')">
       <div class="overlay main">
         <h2><span class="highlight">Leadership</span><i class="fa-solid fa-star icon"></i></h2>
         <p>I enjoy mentoring teams and fostering collaboration to deliver high-quality results. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus at urna vel quam euismod efficitur.</p>

--- a/script.js
+++ b/script.js
@@ -47,12 +47,15 @@ function handleSteps() {
     if (rect.top <= center && rect.bottom >= center) {
       overlay.classList.add('show');
       overlay.classList.remove('exit-up', 'exit-down');
+      step.classList.add('active');
     } else if (rect.top < center) {
       overlay.classList.remove('show');
       overlay.classList.add('exit-up');
+      step.classList.remove('active');
     } else {
       overlay.classList.remove('show');
       overlay.classList.add('exit-down');
+      step.classList.remove('active');
     }
   });
 }

--- a/style.css
+++ b/style.css
@@ -61,6 +61,7 @@ main section {
   flex-direction: column;
   min-height: auto;
   background-attachment: fixed;
+  scroll-snap-type: y mandatory;
 }
 
 .scrolly .step {
@@ -69,6 +70,11 @@ main section {
   align-items: center;
   justify-content: center;
   position: relative;
+  scroll-snap-align: start;
+  transition: transform 0.6s ease;
+}
+.scrolly .step.active {
+  transform: scale(1.05);
 }
 
 .scrolly .step .overlay {


### PR DESCRIPTION
## Summary
- revert Experience and Leadership section to scrolly layout
- use vibrant Edinburgh imagery for each step and add dark overlay

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6857ed7a5d348321969190db7c1f9eda