### PR TITLE
Remove overlay from experience background

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
       <p>With a background in computer science, I enjoy solving complex problems. Duis dapibus, nibh non pretium feugiat, dolor augue congue sapien, a gravida purus metus nec libero. Donec pharetra purus eget massa pulvinar, vel rhoncus lacus placerat.</p>
     </div>
   </section>
-  <section class="scrolly dark-bg" style="background-image:url('https://plus.unsplash.com/premium_photo-1699626665792-77b2eef3a0af?crop=entropy&amp;cs=tinysrgb&amp;fit=max&amp;fm=jpg&amp;ixid=M3wxMjA3fDB8MXxzZWFyY2h8MXx8ZWRpbmJ1cmdofGVufDB8fHx8MTc1MDU5NTU2OHww&amp;ixlib=rb-4.1.0&amp;q=80&amp;w=1080')">
+  <section class="scrolly" style="background-image:url('https://plus.unsplash.com/premium_photo-1699626665792-77b2eef3a0af?crop=entropy&amp;cs=tinysrgb&amp;fit=max&amp;fm=jpg&amp;ixid=M3wxMjA3fDB8MXxzZWFyY2h8MXx8ZWRpbmJ1cmdofGVufDB8fHx8MTc1MDU5NTU2OHww&amp;ixlib=rb-4.1.0&amp;q=80&amp;w=1080')">
     <div class="step">
       <div class="overlay main">
         <h2><span class="highlight">Experience</span><i class="fa-solid fa-briefcase icon"></i></h2>


### PR DESCRIPTION
## Summary
- update `Experience` section to omit the `dark-bg` overlay

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857f9f57d288321b8810d7803cc65b3