### PR TITLE
Add sticky header menu for section navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,15 +11,23 @@
 <body>
 <div id="progress"></div>
 <header>
-  <span class="name">Rishikumar SG</span>
-  <nav>
+  <div class="left">
+    <span class="name">Rishikumar SG</span>
+    <nav class="menu">
+      <a href="#about">About</a>
+      <a href="#experience">Experience</a>
+      <a href="#skills">Skills</a>
+      <a href="#edinburgh">Edinburgh</a>
+    </nav>
+  </div>
+  <nav class="social">
     <a href="https://youtube.com" aria-label="YouTube"><i class="fab fa-youtube"></i></a>
     <a href="https://www.linkedin.com" aria-label="LinkedIn"><i class="fab fa-linkedin"></i></a>
     <a href="https://twitter.com" aria-label="Twitter"><i class="fab fa-twitter"></i></a>
   </nav>
 </header>
 <main>
-  <section class="hero" style="background-image:url('https://i.imgur.com/HAZNReq.jpeg')">
+  <section id="home" class="hero" style="background-image:url('https://i.imgur.com/HAZNReq.jpeg')">
     <div class="shape circle" style="bottom:10%;left:80%;"></div>
     <div class="shape square" style="top:20%;right:10%;"></div>
     <div class="overlay main">
@@ -30,7 +38,7 @@
       <p>This site highlights my work and passions in greater depth. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse potenti. Mauris ac lorem eget nisl convallis tincidunt.</p>
     </div>
   </section>
-  <section style="background-image:url('https://images.unsplash.com/photo-1535448033526-c0e85c9e6968?w=4096')">
+  <section id="about" style="background-image:url('https://images.unsplash.com/photo-1535448033526-c0e85c9e6968?w=4096')">
     <div class="overlay main">
       <h2><span class="highlight">About Me</span><i class="fa-solid fa-user icon"></i></h2>
       <p>I am passionate about technology and love exploring historical cities like Edinburgh. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed blandit libero ut metus faucibus, ac tincidunt nulla laoreet.</p>
@@ -39,7 +47,7 @@
       <p>With a background in computer science, I enjoy solving complex problems. Duis dapibus, nibh non pretium feugiat, dolor augue congue sapien, a gravida purus metus nec libero. Donec pharetra purus eget massa pulvinar, vel rhoncus lacus placerat.</p>
     </div>
   </section>
-  <section class="scrolly dark-bg" style="background-image:url('https://plus.unsplash.com/premium_photo-1699626665792-77b2eef3a0af?crop=entropy&amp;cs=tinysrgb&amp;fit=max&amp;fm=jpg&amp;ixid=M3wxMjA3fDB8MXxzZWFyY2h8MXx8ZWRpbmJ1cmdofGVufDB8fHx8MTc1MDU5NTU2OHww&amp;ixlib=rb-4.1.0&amp;q=80&amp;w=1080')">
+  <section id="experience" class="scrolly dark-bg" style="background-image:url('https://plus.unsplash.com/premium_photo-1699626665792-77b2eef3a0af?crop=entropy&amp;cs=tinysrgb&amp;fit=max&amp;fm=jpg&amp;ixid=M3wxMjA3fDB8MXxzZWFyY2h8MXx8ZWRpbmJ1cmdofGVufDB8fHx8MTc1MDU5NTU2OHww&amp;ixlib=rb-4.1.0&amp;q=80&amp;w=1080')">
     <div class="step">
       <div class="overlay main">
         <h2><span class="highlight">Experience</span><i class="fa-solid fa-briefcase icon"></i></h2>
@@ -59,7 +67,7 @@
       </div>
     </div>
   </section>
-  <section class="skills dark-bg" style="background-image:url('https://images.unsplash.com/photo-1595599014147-a419c147bdc0?w=4096')">
+  <section id="skills" class="skills dark-bg" style="background-image:url('https://images.unsplash.com/photo-1595599014147-a419c147bdc0?w=4096')">
     <div class="overlay main">
       <h2><span class="highlight">Skills</span><i class="fa-solid fa-lightbulb icon"></i></h2>
       <p>
@@ -72,7 +80,7 @@
       <p>I also have experience in DevOps, cloud platforms, and agile practices. Proin luctus, justo vitae congue malesuada, eros velit cursus odio, in efficitur lectus lorem et massa. Nulla facilisi. Aenean eget nulla vitae urna posuere ullamcorper.</p>
     </div>
   </section>
-  <section style="background-image:url('https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Arthur%27s_Seat_from_Calton_Hill_%28cropped%29.jpg/4096px-Arthur%27s_Seat_from_Calton_Hill_%28cropped%29.jpg')">
+  <section id="edinburgh" style="background-image:url('https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Arthur%27s_Seat_from_Calton_Hill_%28cropped%29.jpg/4096px-Arthur%27s_Seat_from_Calton_Hill_%28cropped%29.jpg')">
     <div class="shape circle" style="top:30%;left:15%;"></div>
     <div class="overlay main">
       <h2>Life in <span class="highlight">Edinburgh</span><i class="fa-solid fa-landmark icon"></i></h2>

--- a/style.css
+++ b/style.css
@@ -1,3 +1,7 @@
+html {
+  scroll-behavior: smooth;
+}
+
 body {
   margin: 0;
   font-family: Arial, sans-serif;
@@ -24,11 +28,27 @@ header .name {
   font-weight: bold;
 }
 
-header nav {
+header .left {
+  display: flex;
+  align-items: center;
+}
+
+header nav.menu {
+  margin-left: 1.5rem;
+}
+
+header nav.menu a {
+  color: #E7E7E7;
+  margin-left: 1rem;
+  font-size: 1rem;
+  text-decoration: none;
+}
+
+header nav.social {
   margin-right: 2rem;
 }
 
-header nav a {
+header nav.social a {
   color: #E7E7E7;
   margin-left: 10px;
   font-size: 1.2rem;
@@ -222,7 +242,12 @@ h1, h2, p {
     padding: 0 0.5rem;
   }
 
-  header nav a {
+  header nav.menu a {
+    font-size: 0.9rem;
+    margin-left: 0.5rem;
+  }
+
+  header nav.social a {
     font-size: 1rem;
     margin-left: 6px;
   }


### PR DESCRIPTION
## Summary
- add internal navigation links in header
- assign IDs to each section for linking
- style new header menu and enable smooth scrolling

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6857fa27d07c8321982909690e91ada8